### PR TITLE
search path fix for pg15+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes for apgdiff
 
+## 2024-06-25 / 1.0.2
+
+- fix pg 15+ diffs by always setting the search_path to the schema of the object explicitly
+
 ## 2024-06-24 / 1.0.1
 
 - fix output file not being created automatically if it does not exist

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
         binaries.executable()
     }
 
-    linuxArm64() {
+    linuxArm64 {
         binaries.executable()
     }
 
@@ -86,4 +86,3 @@ lovely {
         }
     }
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048M

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/DropObjectsVisitor.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/DropObjectsVisitor.kt
@@ -6,7 +6,7 @@ import cz.startnet.utils.pgdiff.schema.*
  * A visitor that prints drop statements for any objects that are absent in the new database
  */
 class DropObjectsVisitor(
-    val newDB: PgDatabase,
+    private val newDB: PgDatabase,
     val writer: StringBuilder,
     val options: PgDiffOptions,
 ) : WalkingVisitor() {

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiff.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiff.kt
@@ -4,7 +4,6 @@ import cz.startnet.utils.pgdiff.loader.PgDumpLoader
 import io.github.petertrr.diffutils.diff
 import io.github.petertrr.diffutils.patch.Delta
 import io.github.petertrr.diffutils.patch.DeltaType
-import io.github.petertrr.diffutils.text.DiffRowGenerator
 import kotlinx.io.Source
 
 data class PgDiffResult(
@@ -84,4 +83,3 @@ class PgDiff(
 
     }
 }
-

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffDatabases.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffDatabases.kt
@@ -127,9 +127,9 @@ class PgDiffDatabases(
     private fun updateSchemas() {
         // order schemas by positions of the first relation, to order by schema dependencies
         // TODO: a more safe way would be create all objects based on their position
-        val schemas = newDatabase.schemas.sortedBy {
-            if (it.rels.isNotEmpty()) {
-                it.rels.minOf { it.position }
+        val schemas = newDatabase.schemas.sortedBy { schema ->
+            if (schema.rels.isNotEmpty()) {
+                schema.rels.minOf { it.position }
             } else {
                 0
             }
@@ -258,17 +258,11 @@ class PgDiffDatabases(
             //diffWriter.flush()
             val diffString = schemaWriter.toString() // diff.toString(arguments.outCharsetName) TODO: utf8
             if (diffString.isNotEmpty()) {
-                val setSearchPath = (newDatabase.schemas.size > 1
-                        || newDatabase.schemas[0].name != "public")
-                val searchPathHelper: SearchPathHelper = if (setSearchPath) {
-                    SearchPathHelper(
-                        "SET search_path = "
-                                + PgDiffUtils.getQuotedName(newSchema.name, excludeKeywords = true)
-                                + ", pg_catalog;"
-                    )
-                } else {
-                    SearchPathHelper(null)
-                }
+                val searchPathHelper = SearchPathHelper(
+                    "SET search_path = "
+                            + PgDiffUtils.getQuotedName(newSchema.name, excludeKeywords = true)
+                            + ", pg_catalog;"
+                )
                 searchPathHelper.outputSearchPath(writer)
                 writer.write(diffString)
             }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffSequences.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffSequences.kt
@@ -181,7 +181,7 @@ object PgDiffSequences {
                 sbSQL.append("\tOWNED BY ")
                 sbSQL.append(newOwnedBy)
             }
-            if (sbSQL.length > 0) {
+            if (sbSQL.isNotEmpty()) {
                 writer.println()
                 writer.append(
                     "ALTER SEQUENCE "

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffUtils.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffUtils.kt
@@ -498,9 +498,8 @@ object PgDiffUtils {
         if (name.indexOf('$') != -1 || name.indexOf('-') != -1 || name.indexOf('.') != -1) {
             return '"'.toString() + name + '"'
         }
-        for (i in 0 until name.length) {
-            val chr = name[i]
-            if (chr.isUpperCase()) {
+        for (element in name) {
+            if (element.isUpperCase()) {
                 return '"'.toString() + name + '"'
             }
         }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffViews.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/PgDiffViews.kt
@@ -217,7 +217,7 @@ object PgDiffViews {
         for (oldCol in oldView!!.columns) {
             if (oldCol.defaultValue == null) continue
             val newCol = newView.getColumn(oldCol.name)
-            if (newCol != null && newCol.defaultValue != null) {
+            if (newCol?.defaultValue != null) {
                 if (oldCol.defaultValue != newCol.defaultValue) {
 
                     writer.println()
@@ -245,7 +245,7 @@ object PgDiffViews {
         // add new defaults
         for (newCol in newView.columns) {
             val oldCol = oldView.getColumn(newCol.name)
-            if (oldCol != null && oldCol.defaultValue != null
+            if (oldCol?.defaultValue != null
                 || newCol.defaultValue == null
             ) {
                 continue

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/SearchPathHelper.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/SearchPathHelper.kt
@@ -32,7 +32,7 @@ class SearchPathHelper
      * @param writer writer
      */
     fun outputSearchPath(writer: StringBuilder) {
-        if (!wasOutput && searchPath != null && !searchPath.isEmpty()) {
+        if (!wasOutput && !searchPath.isNullOrEmpty()) {
             writer.println()
             writer.appendLine(searchPath)
             wasOutput = true

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/loader/PgDumpLoader.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/loader/PgDumpLoader.kt
@@ -94,16 +94,13 @@ object PgDumpLoader {
         var pos = sbStatement.indexOf(";")
         while (true) {
             if (pos == -1) {
-                val newLine: String?
-                newLine = reader.readLine()
-                if (newLine == null) {
-                    return if (sbStatement.toString().trim { it <= ' ' }.length == 0) {
+                val newLine: String = reader.readLine()
+                    ?: return if (sbStatement.toString().trim { it <= ' ' }.isEmpty()) {
                         null
                     } else {
                         throw RuntimeException("Cannot find ending semicolon of statement: $sbStatement")
                     }
-                }
-                if (sbStatement.length > 0) {
+                if (sbStatement.isNotEmpty()) {
                     sbStatement.appendLine()
                 }
                 pos = sbStatement.length

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/AlterColumnParser.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/AlterColumnParser.kt
@@ -22,13 +22,13 @@ ALTER [ COLUMN ] column_name SET ( attribute_option = value [, ... ] )
 ALTER [ COLUMN ] column_name RESET ( attribute_option [, ... ] )
 ALTER [ COLUMN ] column_name SET STORAGE { PLAIN | EXTERNAL | EXTENDED | MAIN }
 */
-class AlterColumnParser(val columnName: String, val parser: Parser, val rel: PgRelation<*, *>, val ctx: ParserContext) {
+class AlterColumnParser(private val columnName: String, val parser: Parser, private val rel: PgRelation<*, *>, val ctx: ParserContext) {
 
-    fun getColumnSafe(): PgColumnBase<*, *> {
+    private fun getColumnSafe(): PgColumnBase<*, *> {
         return parser.withErrorContext { rel.getColumnSafe(columnName) }
     }
 
-    fun parseSet() = parser.withErrorContext {
+    private fun parseSet() = parser.withErrorContext {
         if (parser.expectOptional("STATISTICS")) {
             getColumnSafe().statistics = parser.parseInteger()
         } else if (parser.expectOptional("NOT NULL")) {

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CommentParser.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CommentParser.kt
@@ -4,7 +4,7 @@ object CommentParser : PatternBasedSubParser(
     "^COMMENT[\\s]+ON[\\s]+.*$"
 ) {
 
-    val subParsers = listOf(
+    private val subParsers = listOf(
         "EXTENSION" to ::parseExtension,
         "TABLE" to ::parseTable,
         "TYPE" to ::parseType,

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CreateSchemaParser.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CreateSchemaParser.kt
@@ -17,7 +17,7 @@ object CreateSchemaParser : PatternBasedSubParser(
             ctx.database.addSchema(schema)
             schema.authorization = schema.name
             val definition = parser.rest
-            if (definition != null && !definition.isEmpty()) {
+            if (!definition.isNullOrEmpty()) {
                 schema.definition = definition
             }
         } else {
@@ -29,7 +29,7 @@ object CreateSchemaParser : PatternBasedSubParser(
                 schema.authorization = ParserUtils.getObjectName(parser.parseIdentifier())
             }
             val definition = parser.rest
-            if (definition != null && !definition.isEmpty()) {
+            if (!definition.isNullOrEmpty()) {
                 schema.definition = definition
             }
         }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/CreateTriggerParser.kt
@@ -84,9 +84,9 @@ object CreateTriggerParser : PatternBasedSubParser(
 
     private fun parseReferencing(parser: Parser, trigger: PgTrigger): Boolean {
         if (parser.expectOptional("NEW", "TABLE", "AS")) {
-            trigger.referencing = trigger.referencing + " NEW "
+            trigger.referencing += " NEW "
         } else if (parser.expectOptional("OLD", "TABLE", "AS")) {
-            trigger.referencing = trigger.referencing + " OLD "
+            trigger.referencing += " OLD "
         } else {
             return false
         }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/Parser.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/Parser.kt
@@ -76,7 +76,7 @@ class Parser(val string: String, val statementNum: Int = 0) {
         throw parseError(word, position + 1, this.string.substring(position, dumpEndPosition))
     }
 
-    fun parseError(expected: String, startPos: Int, contextString: String = "") =
+    private fun parseError(expected: String, startPos: Int, contextString: String = "") =
         ParserException(
             "Cannot parse string: $string\nExpected $expected at position $startPos ''$contextString''"
         )
@@ -177,8 +177,7 @@ class Parser(val string: String, val statementNum: Int = 0) {
      */
     val rest: String?
         get() {
-            val result: String
-            result = if (string[string.length - 1] == ';') {
+            val result: String = if (string[string.length - 1] == ';') {
                 if (position == string.length - 1) {
                     return null
                 } else {

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/ParserUtils.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/parsers/ParserUtils.kt
@@ -85,13 +85,12 @@ object ParserUtils {
         prefix: String?,
         names: List<String?>, postfix: String?
     ): String {
-        val adjName: String?
-        adjName = if (names.size == 1) {
+        val adjName: String? = if (names.size == 1) {
             names[0]
         } else {
             val sbString = StringBuilder(names.size * 15)
             for (name in names) {
-                if (sbString.length > 0) {
+                if (sbString.isNotEmpty()) {
                     sbString.append(',')
                 }
                 sbString.append(name)
@@ -99,11 +98,11 @@ object ParserUtils {
             sbString.toString().hashCode().toHexString()
         }
         val sbResult = StringBuilder(30)
-        if (prefix != null && !prefix.isEmpty()) {
+        if (!prefix.isNullOrEmpty()) {
             sbResult.append(prefix)
         }
         sbResult.append(adjName)
-        if (postfix != null && !postfix.isEmpty()) {
+        if (!postfix.isNullOrEmpty()) {
             sbResult.append(postfix)
         }
         return sbResult.toString()

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PGVisitor.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PGVisitor.kt
@@ -46,7 +46,7 @@ interface PGVisitor<R> {
 abstract class WalkingVisitor : PGVisitor<Unit> {
 
     lateinit var table: PgTableBase
-    lateinit var db: PgDatabase
+    private lateinit var db: PgDatabase
     lateinit var schema: PgSchema
 
     override fun visit(o: PgDatabase) {
@@ -71,4 +71,3 @@ abstract class WalkingVisitor : PGVisitor<Unit> {
 
 
 }
-

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgColumn.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgColumn.kt
@@ -64,7 +64,7 @@ sealed class PgColumnBase<REL : PgRelation<REL, COL>, COL : PgColumnBase<REL, CO
         sbDefinition.append(quotedIdentifier())
         sbDefinition.append(' ')
         sbDefinition.append(type)
-        if (defaultValue != null && !defaultValue!!.isEmpty()) {
+        if (defaultValue != null && defaultValue!!.isNotEmpty()) {
             sbDefinition.append(" DEFAULT ")
             sbDefinition.append(defaultValue)
         } else if (!nullValue && addDefaults) {
@@ -93,7 +93,7 @@ sealed class PgColumnBase<REL : PgRelation<REL, COL>, COL : PgColumnBase<REL, CO
         return null
     }
 
-    fun quotedIdentifier() = PgDiffUtils.getQuotedName(name)
+    private fun quotedIdentifier() = PgDiffUtils.getQuotedName(name)
 
     fun commentSQL(writer: StringBuilder) {
         val commentStr = comment ?: "NULL"

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgConstraint.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgConstraint.kt
@@ -82,7 +82,7 @@ class PgConstraint(var name: String) {
             sbSQL.append(' ')
             sbSQL.append(definition)
             sbSQL.append(';')
-            if (comment != null && !comment!!.isEmpty()) {
+            if (comment != null && comment!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.appendLine()
                 sbSQL.append("COMMENT ON CONSTRAINT ")
@@ -133,8 +133,7 @@ class PgConstraint(var name: String) {
         if (this === `object`) {
             equals = true
         } else if (`object` is PgConstraint) {
-            val constraint = `object`
-            equals = definition == constraint.definition && name == constraint.name && tableName == constraint.tableName
+            equals = definition == `object`.definition && name == `object`.name && tableName == `object`.tableName
         }
         return equals
     }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgDomain.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgDomain.kt
@@ -10,7 +10,7 @@ data class DomainConstraint(val name: String, val check: String) {
     override fun toString() = sql()
 
     fun sql(): String {
-        return "CONSTRAINT ${quotedIdentifier()} CHECK ${check}"
+        return "CONSTRAINT ${quotedIdentifier()} CHECK $check"
     }
 }
 
@@ -49,4 +49,3 @@ class PgDomain(name: String, position: Int) : DBObject("DOMAIN", name, position)
         }
     }
 }
-

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgIndex.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgIndex.kt
@@ -127,7 +127,7 @@ class PgIndex
             sbSQL.append(' ')
             sbSQL.append(definition)
             sbSQL.append(';')
-            if (comment != null && !comment!!.isEmpty()) {
+            if (comment != null && comment!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.appendLine()
                 sbSQL.append("COMMENT ON INDEX ")
@@ -159,9 +159,8 @@ class PgIndex
         if (this === `object`) {
             equals = true
         } else if (`object` is PgIndex) {
-            val index = `object`
             equals =
-                definition == index.definition && name == index.name && tableName == index.tableName && isUnique == index.isUnique
+                definition == `object`.definition && name == `object`.name && tableName == `object`.tableName && isUnique == `object`.isUnique
         }
         return equals
     }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgRelation.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgRelation.kt
@@ -84,7 +84,7 @@ sealed class PgRelation<REL : PgRelation<REL, COL>, COL : PgColumnBase<REL, COL>
     protected val commentDefinitionSQL: String
         protected get() {
             val sbSQL = StringBuilder(100)
-            if (comment != null && !comment!!.isEmpty()) {
+            if (comment != null && comment!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.appendLine()
                 sbSQL.append("COMMENT ON ")

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgRule.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgRule.kt
@@ -50,14 +50,13 @@ class PgRule(
         if (this === other) {
             equals = true
         } else if (other is PgRule) {
-            val rule = other
             equals =
-                event === rule.event && relationName == rule.relationName && name == rule.name && query == rule.query
+                event === other.event && relationName == other.relationName && name == other.name && query == other.query
         }
         return equals
     }
 
     override val commentSQL: String
-        get() = "COMMENT ON RULE ${quotedIdentifier()} ON ${relationName} IS $comment;"
+        get() = "COMMENT ON RULE ${quotedIdentifier()} ON $relationName IS $comment;"
 
 }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgSequence.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgSequence.kt
@@ -105,7 +105,7 @@ class PgSequence(name: String, position: Int) : DBObject("SEQUENCE", name, posit
                 sbSQL.append("\tCYCLE")
             }
             sbSQL.append(';')
-            if (comment != null && !comment!!.isEmpty()) {
+            if (comment != null && comment!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.appendLine()
                 sbSQL.append("COMMENT ON SEQUENCE ")
@@ -127,7 +127,7 @@ class PgSequence(name: String, position: Int) : DBObject("SEQUENCE", name, posit
             val sbSQL = StringBuilder(100)
             sbSQL.append("ALTER SEQUENCE ")
             sbSQL.append(PgDiffUtils.getQuotedName(name))
-            if (ownedBy != null && !ownedBy!!.isEmpty()) {
+            if (ownedBy != null && ownedBy!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.append("\tOWNED BY ")
                 sbSQL.append(ownedBy)

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgTable.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgTable.kt
@@ -119,8 +119,7 @@ sealed class PgTableBase(
                 } else {
                     sbSQL.append(", ")
                 }
-                var inheritTableName: String?
-                inheritTableName = if (schema.name == inheritPair.first) {
+                var inheritTableName: String? = if (schema.name == inheritPair.first) {
                     inheritPair.second
                 } else {
                     listOf(inheritPair.first, inheritPair.second).joinToString(".")
@@ -129,19 +128,19 @@ sealed class PgTableBase(
             }
             sbSQL.append(")")
         }
-        if (with != null && !with!!.isEmpty()) {
+        if (with != null && with!!.isNotEmpty()) {
             TODO("with clause in table creation not supported")
         }
         if (this is PgForeignTable) {
             sbSQL.append("SERVER ")
             sbSQL.append(foreignServer)
         }
-        if (tablespace != null && !tablespace!!.isEmpty()) {
+        if (tablespace != null && tablespace!!.isNotEmpty()) {
             sbSQL.appendLine()
             sbSQL.append("TABLESPACE ")
             sbSQL.append(tablespace)
         }
-        if (rangePartition != null && !rangePartition!!.isEmpty()) {
+        if (rangePartition != null && rangePartition!!.isNotEmpty()) {
             sbSQL.appendLine()
             sbSQL.append("PARTITION BY RANGE ")
             sbSQL.append(rangePartition)

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgTrigger.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgTrigger.kt
@@ -128,7 +128,7 @@ class PgTrigger(val name: String) {
                     sbSQL.append(" OR")
                 }
                 sbSQL.append(" UPDATE")
-                if (!updateColumns.isEmpty()) {
+                if (updateColumns.isNotEmpty()) {
                     sbSQL.append(" OF")
                     var first = true
                     for (columnName in updateColumns) {
@@ -157,13 +157,13 @@ class PgTrigger(val name: String) {
             sbSQL.append(" ON ")
             sbSQL.append(PgDiffUtils.getQuotedName(relationName))
             sbSQL.appendLine()
-            if (referencing != null && !referencing!!.isEmpty()) {
+            if (referencing != null && referencing!!.isNotEmpty()) {
                 sbSQL.append(referencing)
                 sbSQL.appendLine()
             }
             sbSQL.append("\tFOR EACH ")
             sbSQL.append(if (isForEachRow) "ROW" else "STATEMENT")
-            if (`when` != null && !`when`!!.isEmpty()) {
+            if (`when` != null && `when`!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.append("\tWHEN (")
                 sbSQL.append(`when`)
@@ -173,7 +173,7 @@ class PgTrigger(val name: String) {
             sbSQL.append("\tEXECUTE PROCEDURE ")
             sbSQL.append(function)
             sbSQL.append(';')
-            if (comment != null && !comment!!.isEmpty()) {
+            if (comment != null && comment!!.isNotEmpty()) {
                 sbSQL.appendLine()
                 sbSQL.appendLine()
                 sbSQL.append("COMMENT ON TRIGGER ")
@@ -210,17 +210,16 @@ class PgTrigger(val name: String) {
         if (this === `object`) {
             equals = true
         } else if (`object` is PgTrigger) {
-            val trigger = `object`
-            equals = (eventTimeQualification == trigger.eventTimeQualification
-                    && isForEachRow == trigger.isForEachRow
-                    && function == trigger.function && name == trigger.name && isOnDelete == trigger.isOnDelete
-                    && isOnInsert == trigger.isOnInsert
-                    && isOnUpdate == trigger.isOnUpdate
-                    && isOnTruncate == trigger.isOnTruncate
-                    && relationName == trigger.relationName)
+            equals = (eventTimeQualification == `object`.eventTimeQualification
+                    && isForEachRow == `object`.isForEachRow
+                    && function == `object`.function && name == `object`.name && isOnDelete == `object`.isOnDelete
+                    && isOnInsert == `object`.isOnInsert
+                    && isOnUpdate == `object`.isOnUpdate
+                    && isOnTruncate == `object`.isOnTruncate
+                    && relationName == `object`.relationName)
             if (equals) {
                 val sorted1: List<String> = updateColumns.sorted()
-                val sorted2: List<String?> = trigger.updateColumns.sorted()
+                val sorted2: List<String?> = `object`.updateColumns.sorted()
                 equals = sorted1 == sorted2
             }
         }

--- a/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgView.kt
+++ b/src/commonMain/kotlin/cz/startnet/utils/pgdiff/schema/PgView.kt
@@ -99,7 +99,7 @@ sealed class PgViewBase(name: String, objectType: String, position: Int) : PgRel
             // Can only be set once for a view, before defaults/comments are set
             require(!declareColumnNames)
             require(columns.isEmpty())
-            if (columnNames == null || columnNames.isEmpty()) return
+            if (columnNames.isNullOrEmpty()) return
             declareColumnNames = true
             for (colName in columnNames) {
                 addColumn(PGViewColumn(this, colName))
@@ -142,7 +142,7 @@ sealed class PgViewBase(name: String, objectType: String, position: Int) : PgRel
 
             /* Column default values */for (col in columns) {
                 val defaultValue = col.defaultValue
-                if (defaultValue != null && !defaultValue.isEmpty()) {
+                if (!defaultValue.isNullOrEmpty()) {
                     sbSQL.appendLine()
                     sbSQL.appendLine()
                     sbSQL.append("ALTER ")

--- a/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/DBTest.kt
+++ b/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/DBTest.kt
@@ -60,9 +60,7 @@ class VanillaDBContainer(imageName: String) :
     }
 
     fun dumpDB(dbName: String): String {
-        return exec("pg_dump", "-s", "-d", dbName).let {
-            it.stdout
-        }
+        return exec("pg_dump", "-s", "-d", dbName).stdout
     }
 }
 

--- a/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/TestUtil.kt
+++ b/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/TestUtil.kt
@@ -33,11 +33,11 @@ class SQLDiffFilesArgumentsProvider : ArgumentsProvider {
 
     private val originalPattern = Regex("^(.*)_original.sql")
 
-    override fun provideArguments(context: ExtensionContext): Stream<out Arguments>? {
+    override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
 
-        val names = testFileDir.list()!!.map {
+        val names = testFileDir.list()!!.mapNotNull {
             originalPattern.matchEntire(it)?.groups?.get(1)?.value
-        }.filterNotNull().sorted()
+        }.sorted()
 
         return names.asSequence().map {
             Arguments.of(SQLDiffTestFiles(it))
@@ -57,4 +57,3 @@ fun PgDiffResult.shouldHaveNoDiff() {
     script.shouldBeBlank()
     diffIgnored().joinToString("\n").shouldBeEmpty()
 }
-

--- a/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/loader/PgDumpLoaderTest.kt
+++ b/src/jvmTest/kotlin/cz/startnet/utils/pgdiff/loader/PgDumpLoaderTest.kt
@@ -8,8 +8,8 @@ import java.io.File
 
 class PgDumpLoaderTest {
 
-    fun sqlFiles() = javaClass.getResourceAsStream("/loader_test_files")?.let {
-        it.reader().readLines().filter { it.endsWith(".sql") }
+    private fun sqlFiles() = javaClass.getResourceAsStream("/loader_test_files")?.let { testFiles ->
+        testFiles.reader().readLines().filter { filename -> filename.endsWith(".sql") }
     } ?: error("directory for test files not found")
 
     @ParameterizedTest

--- a/src/jvmTest/resources/pgdiff_test_files/add_cluster_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_cluster_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE testtable2_id_seq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_column_add_defaults_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_column_add_defaults_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE table1
 	ADD COLUMN col2 integer NOT NULL,
 	ADD COLUMN col3 integer DEFAULT 5 NOT NULL;

--- a/src/jvmTest/resources/pgdiff_test_files/add_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_column_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ADD COLUMN field5 boolean DEFAULT false NOT NULL;

--- a/src/jvmTest/resources/pgdiff_test_files/add_column_issue134_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_column_issue134_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test1
 	ADD COLUMN type smallint;

--- a/src/jvmTest/resources/pgdiff_test_files/add_column_issue188_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_column_issue188_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test1
 	ADD COLUMN test2 text DEFAULT '*/'::text,
 	ADD COLUMN test text DEFAULT 'this /*is*/ test'::text,

--- a/src/jvmTest/resources/pgdiff_test_files/add_comment_new_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_comment_new_column_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE agent
 	ADD COLUMN abc bigint;
 COMMENT ON COLUMN agent.id IS 'This ID support schema name';

--- a/src/jvmTest/resources/pgdiff_test_files/add_comment_on_inherited_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_comment_on_inherited_diff.sql
@@ -1,1 +1,3 @@
+
+SET search_path = public, pg_catalog;
 COMMENT ON COLUMN article_drafts.a IS 'comment on inherited';

--- a/src/jvmTest/resources/pgdiff_test_files/add_comments_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_comments_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 COMMENT ON SEQUENCE test_id_seq IS 'test table sequence';
 
 COMMENT ON TABLE test IS 'test table';

--- a/src/jvmTest/resources/pgdiff_test_files/add_constraint_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_constraint_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ADD CONSTRAINT field4check CHECK (((field4 > ('-5.0'::numeric)::double precision) AND (field4 < (5.0)::double precision)));

--- a/src/jvmTest/resources/pgdiff_test_files/add_default_value_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_default_value_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field4 SET DEFAULT 0.0;

--- a/src/jvmTest/resources/pgdiff_test_files/add_defaults_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_defaults_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ADD COLUMN col3 boolean NOT NULL,
 	ADD COLUMN col4 character(10) NOT NULL,

--- a/src/jvmTest/resources/pgdiff_test_files/add_empty_table_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_empty_table_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE empty_table (
 );
 

--- a/src/jvmTest/resources/pgdiff_test_files/add_function_args2_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_function_args2_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION multiply_numbers(number1 integer, number2 integer) RETURNS integer
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/add_function_args_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_function_args_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION power_number("input" integer) RETURNS integer
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/add_function_noargs_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_function_noargs_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION return_one() RETURNS integer
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/add_function_similar_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_function_similar_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION multiply_numbers(number2 smallint, number1 smallint) RETURNS smallint
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/add_index_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_index_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE INDEX testindex3 ON testtable USING btree (field3);

--- a/src/jvmTest/resources/pgdiff_test_files/add_index_only_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_index_only_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE INDEX testindex3 ON testtable USING btree (field3);

--- a/src/jvmTest/resources/pgdiff_test_files/add_inherits_default_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_inherits_default_column_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE childtable (
 )
 INHERITS (parenttable);

--- a/src/jvmTest/resources/pgdiff_test_files/add_inherits_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_inherits_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE testtable (
 	field1 polygon
 )

--- a/src/jvmTest/resources/pgdiff_test_files/add_materialized_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_materialized_view_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE MATERIALIZED VIEW testview AS
 	SELECT testtable.id,
     testtable.name

--- a/src/jvmTest/resources/pgdiff_test_files/add_not_null_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_not_null_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field3 SET NOT NULL;

--- a/src/jvmTest/resources/pgdiff_test_files/add_owned_sequence_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_owned_sequence_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE table2_col1_seq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_sequence_bug2100013_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_sequence_bug2100013_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE test_id_seq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_sequence_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_sequence_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE testseq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_sequence_issue225_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_sequence_issue225_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE alert_alert_id_seq
 	AS integer
 	START WITH 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_statistics_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_statistics_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE ONLY testtable ALTER COLUMN field4 SET STATISTICS 100;

--- a/src/jvmTest/resources/pgdiff_test_files/add_table_bug102_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_table_bug102_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE "procedureresult$Operation" (
 	id bigint NOT NULL,
 	name character varying(255),

--- a/src/jvmTest/resources/pgdiff_test_files/add_table_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_table_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE testtable2 (
 	id integer,
 	name character varying(100) NOT NULL

--- a/src/jvmTest/resources/pgdiff_test_files/add_table_issue115_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_table_issue115_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE test2_id_seq
 	AS integer
 	START WITH 1

--- a/src/jvmTest/resources/pgdiff_test_files/add_table_partition_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_table_partition_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE testtable2 (
 	id integer,
 	name character varying(100) NOT NULL

--- a/src/jvmTest/resources/pgdiff_test_files/add_trigger_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_trigger_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION test_table_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/add_type_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_type_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TYPE bug_status AS ENUM (
 	'new',
 	'open',

--- a/src/jvmTest/resources/pgdiff_test_files/add_unique_constraint_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_unique_constraint_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE inventoryitemsupplier
 	ADD CONSTRAINT inventoryitemsupplier_pkey PRIMARY KEY (id);
 

--- a/src/jvmTest/resources/pgdiff_test_files/add_unlogged_table_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_unlogged_table_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE UNLOGGED TABLE asset_country_weight (
 	asset integer NOT NULL,
 	country character varying(3) NOT NULL,

--- a/src/jvmTest/resources/pgdiff_test_files/add_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/add_view_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE VIEW testview WITH (security_barrier='true') AS
 	SELECT testtable.id,
     testtable.name

--- a/src/jvmTest/resources/pgdiff_test_files/alter_column_generated_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_column_generated_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE TABLE companies (
 	id bigint NOT NULL
 );

--- a/src/jvmTest/resources/pgdiff_test_files/alter_comments_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_comments_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 COMMENT ON SEQUENCE test_id_seq IS 'test table sequence 2';
 
 COMMENT ON TABLE test IS 'test table 2';

--- a/src/jvmTest/resources/pgdiff_test_files/alter_inherited_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_inherited_column_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE ONLY childtable
 	ALTER COLUMN a SET DEFAULT 'child a'::text;
 

--- a/src/jvmTest/resources/pgdiff_test_files/alter_policies_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_policies_diff.sql
@@ -1,3 +1,5 @@
+
+SET search_path = public, pg_catalog;
 ALTER POLICY check_evens_and_1 ON todos TO PUBLIC
 WITH CHECK (
   (((id % 2) = 0) OR (id = 1))

--- a/src/jvmTest/resources/pgdiff_test_files/alter_sequence_owner_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_sequence_owner_diff.sql
@@ -1,1 +1,3 @@
+
+SET search_path = public, pg_catalog;
 ALTER SEQUENCE testseq OWNER TO admin;

--- a/src/jvmTest/resources/pgdiff_test_files/alter_type_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_type_diff.sql
@@ -1,3 +1,5 @@
+
+SET search_path = public, pg_catalog;
 ALTER TYPE bug_status OWNER TO admin;
 COMMENT ON TYPE bug_status IS 'Status of a bug';
 

--- a/src/jvmTest/resources/pgdiff_test_files/alter_view_add_default_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_view_add_default_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test ALTER COLUMN test_col SET DEFAULT now();

--- a/src/jvmTest/resources/pgdiff_test_files/alter_view_change_default_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_view_change_default_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test ALTER COLUMN test_col SET DEFAULT '2020-01-01 00:00:00+00'::timestamp with time zone;

--- a/src/jvmTest/resources/pgdiff_test_files/alter_view_drop_default_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_view_drop_default_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test ALTER COLUMN test_col DROP DEFAULT;

--- a/src/jvmTest/resources/pgdiff_test_files/alter_view_owner_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/alter_view_owner_diff.sql
@@ -1,1 +1,3 @@
+
+SET search_path = public, pg_catalog;
 ALTER VIEW items_view OWNER TO webuser;

--- a/src/jvmTest/resources/pgdiff_test_files/create_domain_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/create_domain_diff.sql
@@ -1,3 +1,5 @@
+
+SET search_path = public, pg_catalog;
 COMMENT ON DOMAIN benefits IS 'benefits comment';
 ALTER DOMAIN benefits DROP NOT NULL;
 

--- a/src/jvmTest/resources/pgdiff_test_files/disable_no_force_rls_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/disable_no_force_rls_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE items DISABLE ROW LEVEL SECURITY;
 
 ALTER TABLE projects NO FORCE ROW LEVEL SECURITY;

--- a/src/jvmTest/resources/pgdiff_test_files/disable_trigger_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/disable_trigger_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE test_table DISABLE TRIGGER test_table_trigger;
 

--- a/src/jvmTest/resources/pgdiff_test_files/drop_cluster_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_cluster_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable SET WITHOUT CLUSTER;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_column_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	DROP COLUMN IF EXISTS field5;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_comments_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_comments_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 COMMENT ON SEQUENCE test_id_seq IS NULL;
 
 COMMENT ON TABLE test IS NULL;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_constraint_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_constraint_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	DROP CONSTRAINT field4check;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_default_value_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_default_value_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field4 DROP DEFAULT;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_index_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_index_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 DROP INDEX testindex3;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_index_with_cluster_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_index_with_cluster_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 DROP INDEX testindex2;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_not_null_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_not_null_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field3 DROP NOT NULL;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_statistics_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_statistics_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE ONLY testtable ALTER COLUMN field4 SET STATISTICS -1;

--- a/src/jvmTest/resources/pgdiff_test_files/drop_trigger_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/drop_trigger_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 DROP TRIGGER test_table_trigger ON test_table;

--- a/src/jvmTest/resources/pgdiff_test_files/enable_force_rls_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/enable_force_rls_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE items ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE projects FORCE ROW LEVEL SECURITY;

--- a/src/jvmTest/resources/pgdiff_test_files/foreign_alter_type_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/foreign_alter_type_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER FOREIGN TABLE foreign_to_alter
 	ADD COLUMN country_code character varying(5),
 	ALTER COLUMN ref2 TYPE character varying(20);

--- a/src/jvmTest/resources/pgdiff_test_files/foreign_create_table_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/foreign_create_table_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE FOREIGN TABLE foreign_to_create (
 	id bigint
 )SERVER myserver

--- a/src/jvmTest/resources/pgdiff_test_files/function_bug3084274_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/function_bug3084274_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION f_obj_execute_node_select(in_id_model bigint, in_id_object text, in_arr_val text, in_mode bigint) RETURNS bigint
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/function_equal_whitespace_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/function_equal_whitespace_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION update_list_subscription_history() RETURNS trigger
     LANGUAGE plpgsql
     AS $$ BEGIN INSERT INTO list_subscription_history (id, areaid, prefixid, msn, j4f_customer_id, subscriptiondate, seqid, refid, price, stopdate) VALUES (OLD.id, OLD.areaid, OLD.prefixid, OLD.msn, OLD.j4f_customer_id, OLD.subscriptiondate, OLD.seqid, OLD.refid, OLD.price, CURRENT_TIMESTAMP); RETURN OLD; END; $$;

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_columns_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_columns_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL (id) ON TABLE todos FROM admin;
 GRANT ALL (id) ON TABLE todos TO admin;
 REVOKE ALL (name) ON TABLE todos FROM anonymous;

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_new_sequence_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_new_sequence_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE task_id_seq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_table_cols_mixed_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_table_cols_mixed_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON TABLE items FROM admin;
 GRANT SELECT, UPDATE ON TABLE items TO admin;
 

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_table_sequence_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_table_sequence_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON SEQUENCE table1_id_seq FROM public;
 GRANT SELECT, USAGE ON SEQUENCE table1_id_seq TO public;
 

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_view_cols_mixed_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_view_cols_mixed_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON TABLE items_view FROM admin;
 GRANT SELECT, UPDATE ON TABLE items_view TO admin;
 

--- a/src/jvmTest/resources/pgdiff_test_files/grant_on_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/grant_on_view_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON TABLE view1 FROM public;
 GRANT SELECT, INSERT ON TABLE view1 TO public;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_cluster_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_cluster_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE INDEX testindex2 ON testtable USING btree (field2);
 
 ALTER TABLE testtable CLUSTER ON testindex2;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_column_type_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_column_type_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field1 TYPE integer USING field1::integer,
 	ALTER COLUMN field3 TYPE character varying(150) USING field3::character varying(150);

--- a/src/jvmTest/resources/pgdiff_test_files/modify_constraint_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_constraint_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	DROP CONSTRAINT field4check;
 

--- a/src/jvmTest/resources/pgdiff_test_files/modify_default_value_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_default_value_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ALTER COLUMN field4 SET DEFAULT 1.0;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_default_value_inherited_column_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_default_value_inherited_column_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE ONLY childtable
 	ALTER COLUMN parenttable_id SET DEFAULT 1;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_function_args2_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_function_args2_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP FUNCTION multiply_numbers(integer, integer);
 CREATE FUNCTION multiply_numbers(number2 integer, number1 integer) RETURNS integer
     LANGUAGE plpgsql

--- a/src/jvmTest/resources/pgdiff_test_files/modify_function_args_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_function_args_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP FUNCTION power_number(integer);
 CREATE FUNCTION power_number(arg_new integer) RETURNS integer
     LANGUAGE plpgsql

--- a/src/jvmTest/resources/pgdiff_test_files/modify_function_end_detection_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_function_end_detection_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION afunction(text, text, numeric) RETURNS numeric
     LANGUAGE plpgsql IMMUTABLE
     AS $_$

--- a/src/jvmTest/resources/pgdiff_test_files/modify_function_noargs_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_function_noargs_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE OR REPLACE FUNCTION return_one() RETURNS integer
     LANGUAGE plpgsql
     AS $$

--- a/src/jvmTest/resources/pgdiff_test_files/modify_function_similar_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_function_similar_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP FUNCTION multiply_numbers(smallint, smallint);
 CREATE FUNCTION multiply_numbers(number1 smallint, number2 smallint) RETURNS smallint
     LANGUAGE plpgsql

--- a/src/jvmTest/resources/pgdiff_test_files/modify_index_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_index_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP INDEX testindex;
 
 CREATE INDEX testindex ON testtable USING btree (field3);

--- a/src/jvmTest/resources/pgdiff_test_files/modify_inherits_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_inherits_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 CREATE SEQUENCE new_parent_id_seq
 	START WITH 1
 	INCREMENT BY 1

--- a/src/jvmTest/resources/pgdiff_test_files/modify_materialized_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_materialized_view_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP MATERIALIZED VIEW IF EXISTS testview CASCADE;
 
 CREATE MATERIALIZED VIEW testview AS

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cache_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cache_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	CACHE 10;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cycle_off_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cycle_off_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	NO CYCLE;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cycle_on_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_cycle_on_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	CYCLE;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_increment_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_increment_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	INCREMENT BY 10;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_maxvalue_set_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_maxvalue_set_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	MAXVALUE 1000
 	START WITH 1000;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_maxvalue_unset_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_maxvalue_unset_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	NO MAXVALUE;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_minvalue_set_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_minvalue_set_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	MINVALUE 1000
 	START WITH 1000;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_minvalue_unset_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_minvalue_unset_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	NO MINVALUE;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_sequence_start_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_sequence_start_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER SEQUENCE testseq
 	START WITH 1000;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_statistics_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_statistics_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE ONLY testtable ALTER COLUMN field4 SET STATISTICS 200;

--- a/src/jvmTest/resources/pgdiff_test_files/modify_trigger_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_trigger_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP TRIGGER test_table_trigger ON test_table;
 
 CREATE TRIGGER test_table_trigger

--- a/src/jvmTest/resources/pgdiff_test_files/modify_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/modify_view_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP VIEW IF EXISTS testview CASCADE;
 
 CREATE VIEW testview AS

--- a/src/jvmTest/resources/pgdiff_test_files/read_inherits_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/read_inherits_diff.sql
@@ -1,3 +1,5 @@
 
+SET search_path = public, pg_catalog;
+
 ALTER TABLE testtable
 	ADD COLUMN field2 information_schema.cardinal_number;

--- a/src/jvmTest/resources/pgdiff_test_files/revoke_on_table_sequence_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/revoke_on_table_sequence_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON SEQUENCE table1_id_seq FROM public;
 
 REVOKE ALL ON TABLE table1 FROM public;

--- a/src/jvmTest/resources/pgdiff_test_files/revoke_on_view_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/revoke_on_view_diff.sql
@@ -1,2 +1,4 @@
 
+SET search_path = public, pg_catalog;
+
 REVOKE ALL ON TABLE view1 FROM public;

--- a/src/jvmTest/resources/pgdiff_test_files/view_alias_with_quote_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/view_alias_with_quote_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP VIEW IF EXISTS foo CASCADE;
 
 CREATE VIEW foo AS

--- a/src/jvmTest/resources/pgdiff_test_files/view_colnames_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/view_colnames_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP VIEW IF EXISTS vx CASCADE;
 
 CREATE VIEW vx AS

--- a/src/jvmTest/resources/pgdiff_test_files/view_triggers_diff.sql
+++ b/src/jvmTest/resources/pgdiff_test_files/view_triggers_diff.sql
@@ -1,4 +1,6 @@
 
+SET search_path = public, pg_catalog;
+
 DROP TRIGGER trg_testview_instead_of_delete ON testview;
 
 DROP TRIGGER trg_testview_instead_of_insert ON testview;


### PR DESCRIPTION
background: https://www.enterprisedb.com/blog/new-public-schema-permissions-postgresql-15
TLDR: starting with pg15, the default `public` schema is not "public" the same way as it was before: users by default are not able to create objects there, and the more important part in our case is that if the search path is not explicitly set before a statement, and you don't specify the schema explicitly, than an error will be thrown. since we're using the `public` schema in the ch universe, and apgdiff omitted setting the search_path by default if there is only one schema, or if the given one is the `public` schema, I had to remove that check and make it to prepend the search_path setter statement unconditionally